### PR TITLE
Fix numpy ragged array error.

### DIFF
--- a/slicer/slicer_internal.py
+++ b/slicer/slicer_internal.py
@@ -444,7 +444,7 @@ class ArrayHandler(BaseHandler):
                 else:
                     ragged = False
                 if ragged:
-                    return numpy.array(inner, dtype=numpy.object)
+                    return numpy.array(inner, dtype=object)
                 else:
                     return numpy.array(inner)
             elif _safe_isinstance(o, "torch", "Tensor"):

--- a/slicer/test_slicer.py
+++ b/slicer/test_slicer.py
@@ -26,7 +26,7 @@ def test_slicer_ragged_numpy():
     values = np.array([
         np.array([0, 1]),
         np.array([2, 3, 4])
-    ])
+    ], dtype=object)
     data = np.array([
         np.array([5, 6, 7]),
     ])


### PR DESCRIPTION
Numpy 1.24.0, released over six months ago, banned the creation of implicit ragged arrays and eliminated aliases like `numpy.object`.
https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations

This PR follows those changes.
