### PR TITLE
Add GH action to run pytest

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,32 @@
+name: tests
+
+on:  
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run_tests:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest numpy pandas scipy torch
+          pip install .
+      - name: Install project
+        run: pip install .
+      - name: Test with pytest
+        run: pytest


### PR DESCRIPTION
Adds a lightweight GH action to run tests with pytest on PRs and on pushes to master.

At present two tests fail, so I've opened an issue #5.
I would advocate for enabling this workflow, and then subsequently fixing the tests.