### PR TITLE
Fix: handle scipy failures due to renaming of scipy.sparse modules in v1.8

### DIFF
--- a/slicer/slicer_internal.py
+++ b/slicer/slicer_internal.py
@@ -567,6 +567,8 @@ class UnifiedDataHandler:
         ("numpy", "ndarray"): ArrayHandler,
         ("scipy.sparse.csc", "csc_matrix"): ArrayHandler,
         ("scipy.sparse.csr", "csr_matrix"): ArrayHandler,
+        ("scipy.sparse._csc", "csc_matrix"): ArrayHandler,
+        ("scipy.sparse._csr", "csr_matrix"): ArrayHandler,
         ("scipy.sparse.dok", "dok_matrix"): ArrayHandler,
         ("scipy.sparse.lil", "lil_matrix"): ArrayHandler,
         ("pandas.core.frame", "DataFrame"): DataFrameHandler,

--- a/slicer/slicer_internal.py
+++ b/slicer/slicer_internal.py
@@ -567,8 +567,6 @@ class UnifiedDataHandler:
         ("numpy", "ndarray"): ArrayHandler,
         ("scipy.sparse.csc", "csc_matrix"): ArrayHandler,
         ("scipy.sparse.csr", "csr_matrix"): ArrayHandler,
-        ("scipy.sparse._csc", "csc_matrix"): ArrayHandler,
-        ("scipy.sparse._csr", "csr_matrix"): ArrayHandler,
         ("scipy.sparse.dok", "dok_matrix"): ArrayHandler,
         ("scipy.sparse.lil", "lil_matrix"): ArrayHandler,
         ("pandas.core.frame", "DataFrame"): DataFrameHandler,
@@ -607,7 +605,7 @@ class UnifiedDataHandler:
 
 
 def _type_name(o: object) -> Tuple[str, str]:
-    return o.__class__.__module__, o.__class__.__name__
+    return _handle_module_aliases(o.__class__.__module__), o.__class__.__name__
 
 
 def _safe_isinstance(
@@ -618,3 +616,16 @@ def _safe_isinstance(
         return o_module == module_name and o_type == type_name
     else:
         return o_module == module_name and o_type in type_name
+
+
+def _handle_module_aliases(module_name):
+    # scipy modules such as "scipy.sparse.csc" were renamed to "scipy.sparse._csc" in v1.8
+    # Standardise by removing underscores for compatibility with either name
+    # Else just pass module name unchanged
+    module_map = {
+        "scipy.sparse._csc": "scipy.sparse.csc",
+        "scipy.sparse._csr": "scipy.sparse.csr",
+        "scipy.sparse._dok": "scipy.sparse.dok",
+        "scipy.sparse._lil": "scipy.sparse.lil",
+    }
+    return module_map.get(module_name, module_name)

--- a/slicer/test_slicer.py
+++ b/slicer/test_slicer.py
@@ -246,6 +246,7 @@ def test_slicer_sparse():
 
     candidates = [csc_array, csr_array, dok_array, lil_array]
     for candidate in candidates:
+        print("testing:", type(candidate))
         slicer = S(candidate)
         actual = slicer[0, 0]
         assert ctr_eq(actual.o, 1)
@@ -341,7 +342,8 @@ def test_operations_1d():
     array = np.array(elements)
     torch_array = torch.tensor(elements)
     containers = [li, tup, array, torch_array, di, series]
-    for _, ctr in enumerate(containers):
+    for ctr in containers:
+        print("testing:", type(ctr))
         slicer = AtomicSlicer(ctr)
 
         assert ctr_eq(slicer[0], elements[0])
@@ -371,7 +373,8 @@ def test_operations_2d():
     sparse_lil = lil_matrix(elements)
 
     containers = [li, df, sparse_csc, sparse_csr, sparse_dok, sparse_lil]
-    for _, ctr in enumerate(containers):
+    for ctr in containers:
+        print("testing:", type(ctr))
         slicer = AtomicSlicer(ctr)
 
         assert ctr_eq(slicer[0], elements[0])
@@ -432,7 +435,8 @@ def test_operations_3d():
         list_of_multi_arrays,
         di_of_multi_arrays,
     ]
-    for _, ctr in enumerate(containers):
+    for ctr in containers:
+        print("testing:", type(ctr))
         slicer = AtomicSlicer(ctr)
 
         assert ctr_eq(slicer[0], elements[0])


### PR DESCRIPTION
Fixes the unit tests, and closes #5 

Changes:
- Handle renaming of scipy.sparse submodules in scipy v1.8
- Slightly more verbose stderr in tests

After this change is in, it would be great to have a release if possible.